### PR TITLE
Add NestJS Keycloak POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore POC2 node modules
+poc2/server/node_modules/

--- a/poc2/README.md
+++ b/poc2/README.md
@@ -1,0 +1,33 @@
+# POC 2: NestJS + PostgreSQL + Keycloak
+
+This proof of concept demonstrates integrating NestJS with a PostgreSQL
+backend secured by Keycloak. Two roles are used: **admin** and
+**supplier**. API routes are protected using `nestjs-keycloak-connect`.
+
+## Structure
+
+```
+poc2/
+  server/  - NestJS backend
+```
+
+- `admin` and `supplier` modules expose separate routes
+- `user` module uses TypeORM for a simple user table
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   cd poc2/server
+   npm install
+   ```
+2. Configure Keycloak and PostgreSQL connection in `src/app.module.ts`.
+3. Start the NestJS server:
+   ```bash
+   npm start
+   ```
+   The server listens on `http://localhost:3002`.
+
+This POC can be combined with the existing realtime dashboard by
+forwarding authenticated requests from the front‑end to the NestJS
+server.

--- a/poc2/client/index.html
+++ b/poc2/client/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>POC 2 Client</title>
+  <script src="https://cdn.jsdelivr.net/npm/keycloak-js@23/dist/keycloak.min.js"></script>
+</head>
+<body>
+  <h1>POC 2 Frontend</h1>
+  <button id="login">Login</button>
+  <pre id="output"></pre>
+  <script>
+    const keycloak = new Keycloak({
+      url: 'http://localhost:8080',
+      realm: 'demo',
+      clientId: 'frontend'
+    });
+    document.getElementById('login').onclick = () => {
+      keycloak.init({ onLoad: 'login-required' }).then(() => {
+        fetch('http://localhost:3002/admin/dashboard', {
+          headers: { Authorization: 'Bearer ' + keycloak.token }
+        })
+          .then(r => r.json())
+          .then(data => {
+            document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+          });
+      });
+    };
+  </script>
+</body>
+</html>

--- a/poc2/server/package.json
+++ b/poc2/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "poc2-server",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "nestjs-keycloak-connect": "^2.4.1",
+    "pg": "^8.11.1",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.19"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/poc2/server/src/admin/admin.controller.ts
+++ b/poc2/server/src/admin/admin.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { Roles } from 'nestjs-keycloak-connect';
+
+@Controller('admin')
+export class AdminController {
+  @Get('dashboard')
+  @Roles('admin')
+  getDashboard() {
+    return { message: 'Admin dashboard data' };
+  }
+}

--- a/poc2/server/src/admin/admin.module.ts
+++ b/poc2/server/src/admin/admin.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+
+@Module({
+  controllers: [AdminController],
+})
+export class AdminModule {}

--- a/poc2/server/src/app.module.ts
+++ b/poc2/server/src/app.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { KeycloakConnectModule } from 'nestjs-keycloak-connect';
+import { UserModule } from './user/user.module';
+import { AdminModule } from './admin/admin.module';
+import { SupplierModule } from './supplier/supplier.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'demo',
+      password: 'demo',
+      database: 'demo',
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    KeycloakConnectModule.register({
+      authServerUrl: 'http://localhost:8080/auth',
+      realm: 'demo',
+      clientId: 'nest-app',
+      secret: 'change-me',
+    }),
+    UserModule,
+    AdminModule,
+    SupplierModule,
+  ],
+})
+export class AppModule {}

--- a/poc2/server/src/auth/keycloak.guard.ts
+++ b/poc2/server/src/auth/keycloak.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from 'nestjs-keycloak-connect';
+
+@Injectable()
+export class KeycloakGuard extends AuthGuard('keycloak') {}

--- a/poc2/server/src/main.ts
+++ b/poc2/server/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3002);
+}
+
+bootstrap();

--- a/poc2/server/src/supplier/supplier.controller.ts
+++ b/poc2/server/src/supplier/supplier.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { Roles } from 'nestjs-keycloak-connect';
+
+@Controller('supplier')
+export class SupplierController {
+  @Get('dashboard')
+  @Roles('supplier')
+  getDashboard() {
+    return { message: 'Supplier dashboard data' };
+  }
+}

--- a/poc2/server/src/supplier/supplier.module.ts
+++ b/poc2/server/src/supplier/supplier.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { SupplierController } from './supplier.controller';
+
+@Module({
+  controllers: [SupplierController],
+})
+export class SupplierModule {}

--- a/poc2/server/src/user/user.controller.ts
+++ b/poc2/server/src/user/user.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { Roles } from 'nestjs-keycloak-connect';
+import { UserService } from './user.service';
+
+@Controller('users')
+export class UserController {
+  constructor(private readonly users: UserService) {}
+
+  @Get()
+  @Roles('admin')
+  findAll() {
+    return this.users.findAll();
+  }
+}

--- a/poc2/server/src/user/user.entity.ts
+++ b/poc2/server/src/user/user.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  username: string;
+
+  @Column()
+  role: string;
+}

--- a/poc2/server/src/user/user.module.ts
+++ b/poc2/server/src/user/user.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+import { UserService } from './user.service';
+import { UserController } from './user.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UserService],
+  controllers: [UserController],
+})
+export class UserModule {}

--- a/poc2/server/src/user/user.service.ts
+++ b/poc2/server/src/user/user.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './user.entity';
+
+@Injectable()
+export class UserService {
+  constructor(@InjectRepository(User) private repo: Repository<User>) {}
+
+  findAll() {
+    return this.repo.find();
+  }
+}

--- a/poc2/server/tsconfig.json
+++ b/poc2/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2017",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add POC2 folder with NestJS + Keycloak demo
- include admin/supplier/user modules for role based access
- add example client page using keycloak-js
- add .gitignore to avoid new node_modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848980040408327b1e7e112f07b2bec