### PR TITLE
Add basic login with role-based views

### DIFF
--- a/realtime-dashboard/server/public/admin.html
+++ b/realtime-dashboard/server/public/admin.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Dashboard</title>
+</head>
+<body>
+  <h2>Admin Dashboard</h2>
+  <p>Welcome, admin!</p>
+  <a href="/logout">Logout</a>
+</body>
+</html>

--- a/realtime-dashboard/server/public/login.html
+++ b/realtime-dashboard/server/public/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <h2>Login</h2>
+  <form method="POST" action="/login">
+    <label>
+      Username:
+      <input type="text" name="username" />
+    </label>
+    <br />
+    <label>
+      Password:
+      <input type="password" name="password" />
+    </label>
+    <br />
+    <button type="submit">Login</button>
+  </form>
+  <p style="color:red;">
+    <!-- Display simple error when query contains ?error=1 -->
+  </p>
+  <script>
+    if (location.search.includes('error=1')) {
+      document.querySelector('p').textContent = 'Invalid credentials';
+    }
+  </script>
+</body>
+</html>

--- a/realtime-dashboard/server/public/supplier.html
+++ b/realtime-dashboard/server/public/supplier.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Supplier Dashboard</title>
+</head>
+<body>
+  <h2>Supplier Dashboard</h2>
+  <p>Welcome, supplier!</p>
+  <a href="/logout">Logout</a>
+</body>
+</html>

--- a/realtime-dashboard/server/src/index.ts
+++ b/realtime-dashboard/server/src/index.ts
@@ -1,10 +1,15 @@
+/// <reference path="./types.d.ts" />
 import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
+import path from 'path';
+import cookie from 'cookie';
 
 const app = express();
 app.use(cors());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, '../public')));
 
 const server = http.createServer(app);
 const io = new Server(server, {
@@ -14,6 +19,39 @@ const io = new Server(server, {
     credentials: true
   }
 });
+
+interface User {
+  username: string;
+  password: string;
+  role: 'admin' | 'supplier';
+}
+
+const users: User[] = [
+  { username: 'admin', password: 'admin123', role: 'admin' },
+  { username: 'supplier', password: 'supplier123', role: 'supplier' }
+];
+
+function auth(role: 'admin' | 'supplier'): express.RequestHandler {
+  return (req, res, next) => {
+    const cookies = cookie.parse(req.headers.cookie || '');
+    if (!cookies.user) {
+      res.redirect('/login.html');
+      return;
+    }
+    try {
+      const user = JSON.parse(cookies.user);
+      if (user.role !== role) {
+        res.status(403).send('Forbidden');
+        return;
+      }
+      (req as any).user = user;
+      next();
+    } catch {
+      res.redirect('/login.html');
+      return;
+    }
+  };
+}
 
 function generateOrderStatus() {
   // 订单总数在 100~300 之间波动
@@ -59,6 +97,41 @@ io.on('connection', (socket) => {
     clearInterval(interval);
     console.log('Client disconnected:', socket.id);
   });
+});
+
+app.get('/', (_req, res) => {
+  res.redirect('/login.html');
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(
+    u => u.username === username && u.password === password
+  );
+  if (!user) {
+    return res.redirect('/login.html?error=1');
+  }
+  res.setHeader(
+    'Set-Cookie',
+    cookie.serialize('user', JSON.stringify({ username: user.username, role: user.role }), {
+      httpOnly: true,
+      maxAge: 60 * 60
+    })
+  );
+  res.redirect(user.role === 'admin' ? '/admin' : '/supplier');
+});
+
+app.get('/admin', auth('admin'), (_req, res) => {
+  res.sendFile(path.join(__dirname, '../public/admin.html'));
+});
+
+app.get('/supplier', auth('supplier'), (_req, res) => {
+  res.sendFile(path.join(__dirname, '../public/supplier.html'));
+});
+
+app.get('/logout', (_req, res) => {
+  res.setHeader('Set-Cookie', cookie.serialize('user', '', { maxAge: -1 }));
+  res.redirect('/login.html');
 });
 
 app.get('/mock', (req, res) => {

--- a/realtime-dashboard/server/src/types.d.ts
+++ b/realtime-dashboard/server/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'cookie';


### PR DESCRIPTION
## Summary
- add simple mock login system with admin/supplier roles
- provide login page and two role-specific dashboards
- include small declaration file for `cookie` module

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6848bdc01c608327b2bc32d55fac8796